### PR TITLE
Update audio_stream.rb

### DIFF
--- a/lib/mumble-ruby/audio_stream.rb
+++ b/lib/mumble-ruby/audio_stream.rb
@@ -20,7 +20,7 @@ module Mumble
     end
 
     def volume=(volume)
-      @volume = volume / 100.0
+      @volume = volume / 50.0
     end
 
     def stop


### PR DESCRIPTION
Playing music through your client works great but there is no way to change the volume of an individual person/bot in mumble client.

Would it be possible to just lower or add the ability to change the volume in mumble-ruby as I specified above.

I am trying to use your mumble-ruby client with a FIFO file to stream music to a mumble server but without the ability to change the volume of the Music Bot it is pointless to have music playing in the background if it is just entirely too loud.

On that note great product I love the work you did with it and this I believe would be a much loved feature.
