### PR TITLE
QUICKFIX for Mumble::ChannelNotFound

### DIFF
--- a/lib/mumble-ruby/client.rb
+++ b/lib/mumble-ruby/client.rb
@@ -183,6 +183,8 @@ module Mumble
 
     def channel_id(channel)
       id = case channel
+           when Hashie::Mash
+             channel.channel_id
            when Messages::ChannelState
              channel.channel_id
            when Fixnum


### PR DESCRIPTION
After updating to 1.0.1 some of my bots had problems with channels (Mumble::ChannelNotFound).

I have made a quickfix for the problem. Maybe you can solve this better, but my bots are working again :)

PS: big THANKS for opus! :+1: 
