### PR TITLE
Move User Function in Mumble::Client

### DIFF
--- a/lib/mumble-ruby/client.rb
+++ b/lib/mumble-ruby/client.rb
@@ -70,12 +70,12 @@ module Mumble
       channels[id]
     end
 
-		def move_user(user, channel)
-			cid = channel_id channel
-			uid = user_session user
-			send_user_state(session: uid, channel_id: cid)
-			channels[cid]
-		end
+    def move_user(user, channel)
+      cid = channel_id channel
+      uid = user_session user
+      send_user_state(session: uid, channel_id: cid)
+      channels[cid]
+    end
 
     def text_user(user, string)
       session = user_session user


### PR DESCRIPTION
Created for allowing the bot to move other users. Useful for moving users from channel to channel in an automated fashion.
