### PR TITLE
Add functionality to register user

### DIFF
--- a/lib/mumble-ruby/user.rb
+++ b/lib/mumble-ruby/user.rb
@@ -40,6 +40,10 @@ module Mumble
       !!deaf || !!self_deaf
     end
 
+    def register
+      client.send_user_state(session: session, user_id: 0)
+    end
+
     def stats
       client.send_user_stats session: session
     end


### PR DESCRIPTION
This commit adds a simple `register` method to the `User` class to allow the registration of users.