### PR TITLE
fixed User#muted? and User#deafened? not returning correct values

### DIFF
--- a/lib/mumble-ruby/user.rb
+++ b/lib/mumble-ruby/user.rb
@@ -33,11 +33,11 @@ module Mumble
     end
 
     def muted?
-      !!mute || !!self_mute
+      !!data['suppress'] || !!data['mute'] || !!self_mute
     end
 
     def deafened?
-      !!deaf || !!self_deaf
+      !!data['deaf'] || !!self_deaf
     end
 
     def stats


### PR DESCRIPTION
I think Ruby used the `mute` method defined above instead of the actual attribute.

Also, `muted?` now returns `true` if an user was suppressed by the channel.