### PR TITLE
Set channel_id to 0 for users in root channel

### DIFF
--- a/lib/mumble-ruby/user.rb
+++ b/lib/mumble-ruby/user.rb
@@ -12,6 +12,13 @@ module Mumble
     attribute :self_mute
     attribute :self_deaf
 
+    def initialize(client, data)
+      super(client, data)
+      if channel_id.nil?
+        self.update({"channel_id" => 0})
+      end
+    end
+
     def current_channel
       client.channels[channel_id]
     end


### PR DESCRIPTION
Set the `channel_id` attribute to `0` for users in the root channel (for which it would otherwise be `nil`). This fixes issue #53.
